### PR TITLE
Change lerna config to use npm and add lazy loaded mfe3 module

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "npmClient": "yarn",
+  "npmClient": "npm",
   "packages": [
     "shell",
     "mfe1", 

--- a/mfe3/src/app/app.module.ts
+++ b/mfe3/src/app/app.module.ts
@@ -4,7 +4,6 @@ import { createCustomElement } from '@angular/elements';
 
 import { AppComponent } from './app.component';
 import { AComponent } from './a/a.component';
-import { BComponent } from './b/b.component';
 import { RouterModule } from '@angular/router';
 import { endsWith } from './router.utils';
 
@@ -13,12 +12,11 @@ import { endsWith } from './router.utils';
     BrowserModule,
     RouterModule.forRoot([
     { matcher: endsWith('a'), component: AComponent },
-    { matcher: endsWith('b'), component: BComponent },
+    { matcher: endsWith('b'), loadChildren: () => import('./b/b.module').then(m => m.BModule)}
 ], { relativeLinkResolution: 'legacy' })
   ],
   declarations: [
     AComponent,
-    BComponent,
     AppComponent
   ],
   providers: [],

--- a/mfe3/src/app/b/b.module.ts
+++ b/mfe3/src/app/b/b.module.ts
@@ -1,0 +1,18 @@
+import { NgModule } from "@angular/core";
+import { RouterModule } from "@angular/router";
+import { endsWith } from "../router.utils";
+import { BComponent } from "./b.component";
+
+@NgModule({
+    imports: [
+        RouterModule.forChild([
+            { matcher: endsWith(''), component: BComponent },
+        ])
+    ],
+    declarations: [
+      BComponent,
+    ],
+    providers: [],
+    bootstrap: []
+  })
+  export class BModule {};


### PR DESCRIPTION
Currently there seems to be a misconfiguration with yarn. Some dependencies aren't being installed properly while utilizing yarn. So switching to using NPM seems to fix this issue for the interim. This relates to an issue discussed here [Issue 6](https://github.com/manfredsteyer/multi-framework-micro-frontend/issues/6)

Also I thought it would be useful to demonstrate lazy loading of feature modules for a Micro-Frontend. Relating to an issue found here [Issue 1](https://github.com/manfredsteyer/multi-framework-micro-frontend/issues/1)

Any thoughts or concerns?